### PR TITLE
Fixed Broken Fork Me Banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
 <body>
     <article>
         {{ content }}
-        <a class="github" href="http://github.com/hackdaymanifesto/hackdaymanifesto.github.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://a248.e.akamai.net/assets.github.com/img/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub"></a>
+        <a class="github" href="http://github.com/hackdaymanifesto/hackdaymanifesto.github.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
         <div class="share">
             <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fhackdaymanifesto.com%2F&amp;t=The+Hack+Day+Manifesto" target="_blank"><img src="http://sharenice.org/images/facebook_com.png" width="16" height="16" alt="Share on Facebook"> Facebook</a>
             <a href="https://twitter.com/intent/tweet?text=The%20Hack%20Day%20Manifesto%20%23hackdaymanifesto&amp;url=http%3A%2F%2Fhackdaymanifesto.com%2F" target="_blank"><img src="http://sharenice.org/images/twitter_com.png" width="16" height="16" alt="Share on Twitter"> Tweet</a>


### PR DESCRIPTION
Can't remember what colour the old banner was but think this is correct.

GitHub have now moved images but provided Permanent URL's (https://github.com/blog/273-github-ribbons)
