### PR TITLE
Added print.css.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,8 +12,10 @@
     <meta property="fb:admins" content="801305146" />
     <meta itemprop="name" content="The Hack Day Manifesto">
     <meta itemprop="description" content="So you’re organising a hack day or hackathon? Here are some basic requirements to make your event a success, and avoid the common pitfalls that could otherwise ruin it. If you cannot provide any of the following, make it clear to guests before registration. Attendees are generally forgiving when clear communication is given.">
-    <link rel="stylesheet" href="/media/css/reset.css">
-    <link rel="stylesheet" href="/media/css/site.css">
+    <link rel="stylesheet" media="screen" href="/media/css/reset.css">
+    <link rel="stylesheet" media="screen" href="/media/css/site.css">
+    <link rel="stylesheet" media="print" href="/media/css/print.css">
+    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -28,15 +30,16 @@
         {{ content }}
         <a class="github" href="http://github.com/hackdaymanifesto/hackdaymanifesto.github.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
         <div class="share">
-            <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fhackdaymanifesto.com%2F&amp;t=The+Hack+Day+Manifesto" target="_blank"><img src="http://sharenice.org/images/facebook_com.png" width="16" height="16" alt="Share on Facebook"> Facebook</a>
-            <a href="https://twitter.com/intent/tweet?text=The%20Hack%20Day%20Manifesto%20%23hackdaymanifesto&amp;url=http%3A%2F%2Fhackdaymanifesto.com%2F" target="_blank"><img src="http://sharenice.org/images/twitter_com.png" width="16" height="16" alt="Share on Twitter"> Tweet</a>
-            <a href="https://plus.google.com/share?url=http%3A%2F%2Fhackdaymanifesto.com%2F&amp;hl=en-US" target="_blank"><img src="http://sharenice.org/images/plus_google_com.png" width="16" height="16" alt="Share on Google+"> Google +1</a>
-            <a href="http://www.reddit.com/r/technology/comments/s2gcg/the_hack_day_manifesto/" target="_blank"><img src="http://sharenice.org/images/reddit_com.png" width="16" height="16" alt="Share on Reddit"> Reddit</a>
-            <a href="http://news.ycombinator.com/item?id=3821900" target="_blank"><img src="http://ycombinator.com/favicon.ico" width="16" height="16" alt="Share on Hacker News"> Hacker News</a>
+            <a href="javascript:window.print()"><i class="fa fa-print"></i> Print</a>
+            <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fhackdaymanifesto.com%2F&amp;t=The+Hack+Day+Manifesto" target="_blank"><i class="fa fa-facebook-official"></i> Facebook</a>
+            <a href="https://twitter.com/intent/tweet?text=The%20Hack%20Day%20Manifesto%20%23hackdaymanifesto&amp;url=http%3A%2F%2Fhackdaymanifesto.com%2F" target="_blank"><i class="fa fa-twitter"></i> Tweet</a>
+            <a href="https://plus.google.com/share?url=http%3A%2F%2Fhackdaymanifesto.com%2F&amp;hl=en-US" target="_blank"><i class="fa fa-google-plus-square"></i> Google +1</a>
+            <a href="http://www.reddit.com/r/technology/comments/s2gcg/the_hack_day_manifesto/" target="_blank"><i class="fa fa-reddit"></i> Reddit</a>
+            <a href="http://news.ycombinator.com/item?id=3821900" target="_blank"><i class="fa fa-hacker-news"></i> Hacker News</a>
         </div>
     </article>
     <footer>
-        <p><small>&copy; 2012 <a href='http://creativecommons.org/licenses/by/3.0/'>SOME RIGHTS RESERVED</a></small></p>
+        <p><small>&copy; 2015 <a href="http://creativecommons.org/licenses/by/3.0/">SOME RIGHTS RESERVED</a> <span>&bull; <a href="http://hackdaymanifesto.com/">hackdaymanifesto.com</span></small></p>
     </footer>
     <script>
         var _gaq = _gaq || [];

--- a/media/css/print.css
+++ b/media/css/print.css
@@ -1,0 +1,54 @@
+* {
+  color: #000;
+  background: transparent;
+  font-family: minion-pro, serif;
+  font-size: 11pt;
+}
+
+@page {
+  margin: 0.5in;
+}
+
+h1, h1 a, h2, h3, h3 em, footer p small, footer p small a {
+  font-family: futura-pt, sans-serif;
+}
+
+h1,
+h1 a {
+  font-size: 24pt;
+}
+
+h2 {
+  font-size: 18pt;
+  border-bottom: 1pt solid #999;
+}
+
+h3 {
+  font-size: 14pt;
+  margin-bottom: 0;
+}
+
+h3 + p {
+  margin-top: 0;
+}
+
+h3 em {
+  color: #222;
+  float: right;
+}
+
+#supporters,
+.supporters,
+.share,
+.github img,
+article p:last-of-type {
+  display: none;
+}
+
+a {
+  text-decoration: none;
+}
+
+a[href^="http"] {
+  content: " (" attr(href) ") "
+}

--- a/media/css/site.css
+++ b/media/css/site.css
@@ -66,15 +66,15 @@ footer p {
     margin: 0;
 }
 
-.share {
-    text-align: center;
+footer p span {
+    display: none;
 }
 
 .share a {
     color: #000;
     display: inline-block;
     font-family: Verdana, Helvetica, sans-serif;
-    font-size: 11px;
+    font-size: 12px;
     height: 16px;
     line-height: 16px;
     margin-right: 3px;
@@ -85,6 +85,22 @@ footer p {
 
 .share a:hover {
     opacity: 0.75;
+}
+
+.fa-facebook-official {
+  color: rgb(58,87,149);
+}
+
+.fa-twitter {
+  color: rgb(84,170,236);
+}
+
+.fa-google-plus-square {
+  color: rgb(219,74,57);
+}
+
+.fa-hacker-news {
+  color: rgb(255,102,0);
 }
 
 @media (min-width: 500px) {


### PR DESCRIPTION
Worked on some of the ideas in #86.

**Main changes**
- Added print.css.
- Added javascript link to open print dialogue.

**Other tweaks**
- Swapped out the images for Font Awesome icons and added appropriate coloring.
- Removed centering on `.share` (since the icons/links stretch nicely across the column)
- Updated copyright date to 2015.
- Added a `span` in footer with hackdaymanifesto.com url to appear when printed.

Worth noting: When printed, the document is 10 pages long. That's with the supporters, share links and GitHub instructions removed. 

Hope this helps. :)