### PR TITLE
Adding section on 'attitude to winners'

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -472,6 +472,18 @@ are likely to just disappoint the winning team. When organizations/individuals
 wish to pursue further development of a hack they should speak to the winning
 team separately.
 
+### Attitude to prize winners
+
+Those who have won a prize at a hack day should not be expected to provide any
+ongoing service or favours to sponsors or organisers. Some hack day sponsors
+have been known to ask prize winners to write promotional blog posts for them.
+This kind of behaviour from sponsors can make quite prize winning participants
+quite uncomfortable and unlikely to wish to participate in future events.
+
+What may seem natural to outgoing marketers and CEOs may feel a lot less
+pleasant for more shy and introverted (especially new) developers, designers
+etc.
+
 ## Atmosphere and attitudes
 
 ### Don't make people feel unwelcome
@@ -671,3 +683,4 @@ not just successful, but enjoyable as well. Good luck!
 
 [self]: http://hackdaymanifesto.com/ "The Hack Day Manifesto"
 [github]: https://github.com/hackdaymanifesto/hackdaymanifesto.github.com/ "Fork on GitHub"
+


### PR DESCRIPTION
I have heard a number of developers say that having participated in, and won, a hackday, sponsors have felt that they are some kind of prize horse they can show off for marketing purposes. This is a poor idea and likely to make shy or nervous participants avoid future events.

Developers are there to build ideas out, not to be a co-opted marketing opportunity.

Here's a suggestion for a brief section on how not to treat hackday prize winners...